### PR TITLE
Router Improvements. Improve Pop Behavior: Use Parent Router Reference & Add Root Router Dismiss Option

### DIFF
--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -199,7 +199,7 @@ extension Router {
     ///     var body: some View {
     ///         VStack {
     ///             Button("Close") {
-    ///                 router.dismiss() // Dismisses the current modal or presentation
+    ///                 router.dismissChild() // Dismisses the current modal or presentation
     ///             }
     ///         }
     ///     }

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -39,6 +39,18 @@ public class Router<Destination: Routable>: ObservableObject {
     }
 }
 
+// MARK: - Helper Properties
+extension Router {
+
+    private var rootRouter: Router {
+        var current = self
+        while let parent = current.parentRouter {
+            current = parent
+        }
+        return current
+    }
+}
+
 // MARK: - View Handling
 extension Router {
     /// Returns the initial view for a `RoutingView` based on the provided `Destination`.
@@ -235,7 +247,14 @@ extension Router {
     public func dismissSelf() {
         parentRouter?.dismissChild()
     }
-    
+
+    /// Dismisses entire hierarchy and
+    public func dismissAllFromRoot() {
+        rootRouter.presentingSheet = nil
+        rootRouter.presentingFullScreenCover = nil
+        rootRouter.popToRoot()
+    }
+
     private func push(_ appRoute: Destination) {
         path.append(appRoute)
     }

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -138,31 +138,38 @@ extension Router {
         }
     }
     
-    /// Pops the top view from the navigation stack.
+    /// Removes one or more views from the navigation stack.
     ///
-    /// This method removes the most recently pushed view from the `NavigationPath`,
-    /// effectively navigating **back one screen** in the navigation hierarchy.
+    /// This method removes the most recently pushed views from the `NavigationPath`,
+    /// effectively navigating back one or more screens in the navigation hierarchy.
     ///
-    /// If the navigation stack is **not empty**, the last view is removed.
-    /// If the stack is already empty, calling this method has no effect.
+    /// - If the navigation stack is **not empty**, the specified number of views are removed.
+    /// - If the requested number exceeds available views, all remaining views are removed.
+    /// - If the stack is already empty, calling this method has no effect.
+    /// - If a negative value is provided, the method does nothing.
     ///
+    /// - Parameter last: The number of views to pop from the stack. Defaults to 1.
     /// - Note: This method only affects **push-based navigation** and does not dismiss modals.
     ///
     /// ### Example Usage:
     /// ```swift
     /// struct ViewA: View {
-    ///     // . . .
+    ///     @EnvironmentObject var router: Router<AppRoute>
+    ///
     ///     var body: some View {
-    ///        Button("Go Back") {
-    ///             router.pop() // Navigates back one screen
+    ///         VStack {
+    ///             // Go back one screen
+    ///             Button("Back") { router.pop() }
+    ///
+    ///             // Go back three screens (or as many as available)
+    ///             Button("Back to Main") { router.pop(last: 3) }
     ///         }
     ///     }
     /// }
     /// ```
-    public func pop() {
-        if !path.isEmpty {
-            path.removeLast()
-        }
+    public func pop(last: Int = 1) {
+        guard !path.isEmpty else { return }
+        path.removeLast(last)
     }
     
     /// Pop to the root screen. Removes all views from navigation stack.

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -241,7 +241,7 @@ extension Router {
         parentRouter?.dismissChild()
     }
 
-    /// Dismisses entire hierarchy and
+    /// Dismisses entire hierarchy
     public func dismissAllFromRoot() {
         rootRouter.presentingSheet = nil
         rootRouter.presentingFullScreenCover = nil

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -171,7 +171,7 @@ extension Router {
     /// ```
     public func pop(last: Int = 1) {
         guard !path.isEmpty else { return }
-        path.removeLast(last)
+        path.removeLast(min(last, path.count))
     }
     
     /// Pop to the root screen. Removes all views from navigation stack.

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -10,8 +10,6 @@ public class Router<Destination: Routable>: ObservableObject {
     @Published var presentingFullScreenCover: Destination?
     /// Reference to parent to be able to dismiss
     private weak var parentRouter: Router<Destination>?
-    /// Reference to child Router to be able to reference the last router
-    private var childRouter: Router<Destination>?
 
     /// Indicates whether a modal or full-screen presentation is currently active.
     ///
@@ -91,13 +89,9 @@ extension Router {
         case .push:
             return self
         case .fullScreenCover:
-            let child = Router(parentRouter: self)
-            childRouter = child
-            return child
+            return Router(parentRouter: self)
         case .sheet:
-            let child = Router(parentRouter: self)
-            childRouter = child
-            return child
+            return Router(parentRouter: self)
         }
     }
 }
@@ -219,7 +213,6 @@ extension Router {
         } else if presentingFullScreenCover != nil {
             presentingFullScreenCover = nil
         }
-        childRouter = nil
     }
     
     /// Dismisses the router itself if it was presented by a parent.


### PR DESCRIPTION
I really like this library and decided to extend some of the available options a bit, maybe someone else will find these useful too!

- Improved pop by adding a last parameter to allow dismissing the last two screens (minimum to root).

- Replaced isPresenting with a `parentRouter` reference for more reliable pop behavior.

- Added a `rootRouter` option to enable dismissing all screens at once.

- These changes improve navigation control and simplify dismissing multiple stacked screens.
- Made the router initializer optional with a default nil value, so now you can simply do:
`@StateObject var router: Router<ExampleRoute> = .init()`
