### PR TITLE
Add NavigationTarget for Flexible Hierarchical Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import SwiftUI
 import Routing
 
 struct ContentView: View {
-    @StateObject var router: Router<ExampleRoute> = .init(isPresented: .constant(.none))
+    @StateObject var router = Router<ExampleRoute>()
     
     var body: some View {
         RoutingView(router) { _ in
@@ -153,7 +153,7 @@ import SwiftUI
 import Routing
 
 struct ContentView: View {
-    @StateObject var router: Router<ExampleRoute> = .init(isPresented: .constant(.none))
+    @StateObject var router = Router<ExampleRoute>()
     
     var body: some View {
         RoutingView(router) { _ in
@@ -186,8 +186,8 @@ import SwiftUI
 import Routing
 
 struct MainTabView: View {
-    @StateObject var routerA = Router<ExampleRouteA>(isPresented: .constant(nil))
-    @StateObject var routerB = Router<ExampleRouteB>(isPresented: .constant(nil))
+    @StateObject var routerA = Router<ExampleRouteA>()
+    @StateObject var routerB = Router<ExampleRouteB>()
 
     var body: some View {
         TabView {

--- a/Sources/Routing/Models/NavigationType.swift
+++ b/Sources/Routing/Models/NavigationType.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+public enum NavigationType {
+    /// A push transition style, commonly used in navigation controllers.
+    case push
+    /// A presentation style, often used for modal or overlay views.
+    case fullScreenCover
+    /// A sheet presentation style
+    case sheet
+}
+
+public enum NavigationTarget {
+    /// Use this router instance
+    case current
+    /// Use furthest child in hierarchy
+    case deepest
+    /// Use top-most parent
+    case root
+    /// Use parent router
+    case parent
+    /// Use child router
+    case child
+}

--- a/Sources/Routing/Models/NavigationType.swift
+++ b/Sources/Routing/Models/NavigationType.swift
@@ -12,12 +12,12 @@ public enum NavigationType {
 public enum NavigationTarget {
     /// Use this router instance
     case current
-    /// Use furthest child in hierarchy
-    case deepest
-    /// Use top-most parent
-    case root
     /// Use parent router
     case parent
     /// Use child router
     case child
+    /// Use top-most parent (root)
+    case root
+    /// Use furthest child in hierarchy (deepest)
+    case deepest
 }

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -227,35 +227,21 @@ extension Router {
         path = .init(newStack)
     }
     
-    /// Dismisses the currently presented child modal (sheet or full-screen cover).
+    /// Dismisses the currently presented modal (sheet or full-screen cover).
     ///
-    /// This method checks and dismisses the currently active presentation in the following order:
-    /// 1. If a **sheet**  is presented, it is dismissed.
-    /// 2. If a **full-screen cover** is presented, it is dismissed.
+    /// This method clears both `presentingSheet` and `presentingFullScreenCover`,
+    /// ensuring any active modal presentation is dismissed.
     ///
-    /// - Note: This method only dismisses **modals and presentations**, not pushed views within the navigation stack.
-    /// To navigate back in the stack, use `pop()` instead.
+    /// - Note: SwiftUI only allows one modal presentation at a time, so typically only one of these will be non-nil.
     ///
     /// ### Example Usage:
     /// ```swift
-    /// struct ContentView: View {
-    ///     @StateObject var router = Router<ExampleRoute>()
-    ///
-    ///     var body: some View {
-    ///         VStack {
-    ///             Button("Close") {
-    ///                 router.dismissChild() // Dismisses the current modal or presentation
-    ///             }
-    ///         }
-    ///     }
-    /// }
+    /// router.dismissChild()
     /// ```
     public func dismissChild() {
-        if presentingSheet != nil {
-            presentingSheet = nil
-        } else if presentingFullScreenCover != nil {
-            presentingFullScreenCover = nil
-        }
+        presentingSheet = nil
+        presentingFullScreenCover = nil
+        childRouter = nil
     }
     
     /// Dismisses the router itself if it was presented by a parent.
@@ -281,13 +267,13 @@ extension Router {
     /// }
     /// ```
     public func dismissSelf() {
+        dismissChild() // in case there is presented from self dismiss also
         parentRouter?.dismissChild()
     }
 
     /// Dismisses entire hierarchy
     public func dismissAllFromRoot() {
-        rootRouter.presentingSheet = nil
-        rootRouter.presentingFullScreenCover = nil
+        rootRouter.dismissChild()
         rootRouter.popToRoot()
     }
 

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -141,7 +141,7 @@ extension Router {
 
 // MARK: - Navigation Functions
 extension Router {
-    /// Routes to the specified `Destination` using the given `NavigationType`.
+    /// Routes to the specified `Destination` using the given `NavigationType` and `NavigationTarget`.
     ///
     /// - Parameters:
     ///   - route: The `Destination` to navigate to.
@@ -149,6 +149,12 @@ extension Router {
     ///      - `.push` → Pushes the destination onto the navigation stack.
     ///      - `.sheet` → Presents the destination as a modal sheet.
     ///      - `.fullScreenCover` → Presents the destination as a full-screen cover.
+    ///   - target: The `NavigationTarget` that determines which router instance should handle the navigation.
+    ///      - `.current` → Uses the current router instance.
+    ///      - `.parent` → Routes through the parent router, if any.
+    ///      - `.child` → Routes through the child router, if any.
+    ///      - `.root` → Routes through the root-most router in the hierarchy.
+    ///      - `.deepest` → Routes through the deepest active child router in the hierarchy.
     ///
     /// ### Example Usage:
     /// ```swift
@@ -157,21 +163,22 @@ extension Router {
     ///
     ///     var body: some View {
     ///         VStack {
-    ///             Button("Go to Details (Push)") {
-    ///                 router.routeTo(.details(id: "123"), via: .push) // Pushes onto the navigation stack
+    ///             Button("Push to Details") {
+    ///                 router.routeTo(.details(id: "123"), via: .push) // Pushes from current router
     ///             }
     ///
-    ///             Button("Go to Settings (Sheet)") {
-    ///                 router.routeTo(.settings, via: .sheet) // Presents as a sheet
+    ///             Button("Present Sheet in Deepest Context") {
+    ///                 router.routeTo(.settings, via: .sheet, target: .deepest) // Presents sheet using deepest child router
     ///             }
     ///
-    ///             Button("Go to Profile (Full Screen)") {
-    ///                 router.routeTo(.profile, via: .fullScreenCover) // Presents as full-screen
+    ///             Button("Show Full Screen from Root") {
+    ///                 router.routeTo(.profile, via: .fullScreenCover, target: .root) // Presents from root router
     ///             }
     ///         }
     ///     }
     /// }
     /// ```
+
     public func routeTo(_ route: Destination, via navigationType: NavigationType, target: NavigationTarget = .current) {
         switch navigationType {
         case .push:

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -267,7 +267,10 @@ extension Router {
     /// }
     /// ```
     public func dismissSelf() {
-        dismissChild() // in case there is presented from self dismiss also
+        dismissChild() // in case something is presented dismiss also
+        if !path.isEmpty {
+            popToRoot() // if not empty we wont be able to self dismiss
+        }
         parentRouter?.dismissChild()
     }
 

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -267,17 +267,14 @@ extension Router {
     ///     var body: some View {
     ///         VStack {
     ///             Button("Close Self") {
-    ///                 router.dismissSelf() // Requests the parent to dismiss this router
+    ///                 router.dismissSelf() // Requests parent to dismiss this router and its presentations
     ///             }
     ///         }
     ///     }
     /// }
     /// ```
     public func dismissSelf() {
-        dismissChild() // in case something is presented dismiss also
-        if !path.isEmpty {
-            popToRoot() // if not empty we wont be able to self dismiss
-        }
+        dismissChild() // Dismiss any presented sheet or full-screen modal first
         parentRouter?.dismissChild()
     }
 

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -235,7 +235,7 @@ extension Router {
     
     /// Dismisses the currently presented modal (sheet or full-screen cover).
     ///
-    /// This method clears both `presentingSheet` and `presentingFullScreenCover`,
+    /// This method dismisses both `presentingSheet` and `presentingFullScreenCover`,
     /// ensuring any active modal presentation is dismissed.
     /// SwiftUI only allows one modal presentation at a time, so typically only one of these will be non-nil.
     ///
@@ -278,14 +278,13 @@ extension Router {
     ///     var body: some View {
     ///         VStack {
     ///             Button("Close Self") {
-    ///                 router.dismissSelf() // Requests parent to dismiss this router and its presentations
+    ///                 router.dismissSelf() // Requests the parent to dismiss this router
     ///             }
     ///         }
     ///     }
     /// }
     /// ```
     public func dismissSelf() {
-        dismissChild() // Dismiss any presented sheet or full-screen modal first
         parentRouter?.dismissChild()
     }
 

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -237,8 +237,10 @@ extension Router {
     ///
     /// This method clears both `presentingSheet` and `presentingFullScreenCover`,
     /// ensuring any active modal presentation is dismissed.
+    /// SwiftUI only allows one modal presentation at a time, so typically only one of these will be non-nil.
     ///
-    /// - Note: SwiftUI only allows one modal presentation at a time, so typically only one of these will be non-nil.
+    /// - Note: This method only dismisses **modals and presentations**, not pushed views within the navigation stack.
+    /// To navigate back in the stack, use `pop()` instead.
     ///
     /// ### Example Usage:
     /// ```swift

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -22,7 +22,7 @@ public class Router<Destination: Routable>: ObservableObject {
     ///
     /// ### Example Usage:
     /// ```swift
-    /// let router = Router<ExampleRoute>(isPresented: .constant(nil))
+    /// let router = Router<ExampleRoute>()
     ///
     /// if router.isPresenting {
     ///     print("A modal is currently being presented")
@@ -153,7 +153,7 @@ extension Router {
     /// ### Example Usage:
     /// ```swift
     /// struct ContentView: View {
-    ///     @StateObject var router = Router<ExampleRoute>(isPresented: .constant(nil))
+    ///     @StateObject var router = Router<ExampleRoute>()
     ///
     ///     var body: some View {
     ///         VStack {
@@ -239,7 +239,7 @@ extension Router {
     /// ### Example Usage:
     /// ```swift
     /// struct ContentView: View {
-    ///     @StateObject var router = Router<ExampleRoute>(isPresented: .constant(nil))
+    ///     @StateObject var router = Router<ExampleRoute>()
     ///
     ///     var body: some View {
     ///         VStack {
@@ -269,7 +269,7 @@ extension Router {
     /// ### Example Usage:
     /// ```swift
     /// struct ContentView: View {
-    ///     @StateObject var router = Router<ExampleRoute>(isPresented: .constant(nil))
+    ///     @StateObject var router = Router<ExampleRoute>()
     ///
     ///     var body: some View {
     ///         VStack {

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -39,14 +39,14 @@ public class Router<Destination: Routable>: ObservableObject {
         parentRouter == nil
     }
 
-    /// Indicates whether this router has an active child router.
-    public var hasChild: Bool {
-        childRouter != nil
-    }
-
     /// Indicates whether the router is at the root with no path and no modal presentation.
     public var isFullyAtRoot: Bool {
         isRoot && path.isEmpty && !isPresenting
+    }
+
+    /// Indicates whether this router has an active child router.
+    public var hasChild: Bool {
+        childRouter != nil
     }
 
     /// Initializes a new router with an optional reference to a parent router.

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -163,22 +163,21 @@ extension Router {
     ///
     ///     var body: some View {
     ///         VStack {
-    ///             Button("Push to Details") {
-    ///                 router.routeTo(.details(id: "123"), via: .push) // Pushes from current router
+    ///             Button("Go to Details (Push)") {
+    ///                 router.routeTo(.details(id: "123"), via: .push) // Pushes onto the navigation stack
     ///             }
     ///
-    ///             Button("Present Sheet in Deepest Context") {
-    ///                 router.routeTo(.settings, via: .sheet, target: .deepest) // Presents sheet using deepest child router
+    ///             Button("Go to Settings (Sheet)") {
+    ///                 router.routeTo(.settings, via: .sheet) // Presents as a sheet
     ///             }
     ///
-    ///             Button("Show Full Screen from Root") {
-    ///                 router.routeTo(.profile, via: .fullScreenCover, target: .root) // Presents from root router
+    ///             Button("Go to Profile (Full Screen)") {
+    ///                 router.routeTo(.profile, via: .fullScreenCover) // Presents as full-screen
     ///             }
     ///         }
     ///     }
     /// }
     /// ```
-
     public func routeTo(_ route: Destination, via navigationType: NavigationType, target: NavigationTarget = .current) {
         switch navigationType {
         case .push:
@@ -243,8 +242,17 @@ extension Router {
     ///
     /// ### Example Usage:
     /// ```swift
-    /// router.dismissChild()
-    /// ```
+    /// struct ContentView: View {
+    ///     @StateObject var router = Router<ExampleRoute>()
+    ///
+    ///     var body: some View {
+    ///         VStack {
+    ///             Button("Close") {
+    ///                 router.dismissChild() // Dismisses the current presentation
+    ///             }
+    ///         }
+    ///     }
+    /// }
     public func dismissChild() {
         presentingSheet = nil
         presentingFullScreenCover = nil

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -233,10 +233,9 @@ extension Router {
         path = .init(newStack)
     }
     
-    /// Dismisses the currently presented modal (sheet or full-screen cover).
+    /// Dismisses the currently presented child modal (sheet or full-screen cover).
     ///
-    /// This method dismisses both `presentingSheet` and `presentingFullScreenCover`,
-    /// ensuring any active modal presentation is dismissed.
+    /// This method dismisses both `presentingSheet` and `presentingFullScreenCover`, ensuring any active modal presentation is dismissed.
     /// SwiftUI only allows one modal presentation at a time, so typically only one of these will be non-nil.
     ///
     /// - Note: This method only dismisses **modals and presentations**, not pushed views within the navigation stack.

--- a/Sources/Routing/Models/Router.swift
+++ b/Sources/Routing/Models/Router.swift
@@ -253,6 +253,7 @@ extension Router {
     ///         }
     ///     }
     /// }
+    /// ```
     public func dismissChild() {
         presentingSheet = nil
         presentingFullScreenCover = nil

--- a/Sources/Routing/Protocols/Routable.swift
+++ b/Sources/Routing/Protocols/Routable.swift
@@ -1,11 +1,5 @@
 import SwiftUI
 
-public enum NavigationType {
-    case push
-    case sheet
-    case fullScreenCover
-}
-
 public protocol Routable: Hashable, Identifiable {
     associatedtype ViewType: View
     func viewToDisplay(router: Router<Self>) -> ViewType

--- a/Tests/RoutingTests/RoutingTests.swift
+++ b/Tests/RoutingTests/RoutingTests.swift
@@ -7,7 +7,7 @@ final class RoutingTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        router = Router(isPresented: .constant(.none))
+        router = Router()
     }
     
     override func tearDown() {


### PR DESCRIPTION
This PR introduces the NavigationTarget enum, which allows navigation actions (push, presentSheet, presentFullScreen) to target a specific router in the hierarchy:

```
enum NavigationTarget {
  case current
  case parent
  case child
  case root
  case deepest
}
```
This makes it easier to coordinate navigation in nested flows, deep links, or modal presentations.

✅ Why
Every modal (.sheet, .fullScreenCover) creates a new Router instance via RoutingView, becoming a child of the presenting router. This hierarchy can grow as flows stack.

With NavigationTarget, navigation logic becomes cleaner and less coupled to a specific router. You just express where you want to navigate, and the router system handles the rest.

🎯 Examples
From root, push into the deepest router
`router.routeTo(.step1, via: .push, target: .deepest)`

Present from within an existing modal
`router.routeTo(.step2, via: .fullScreenCover, target: .child)`

Dismiss modal, then continue in parent
```
router.dismissSelf()
router.routeTo(.nextStep, via: .push, target: .parent)
```
🆕 Modal Stacking
You no longer need to manually dismiss modals before presenting new ones. (like in deeplink handling)

If a router is already presenting a screen, the system finds the next available child (.deepest) and presents from there. This avoids modal conflicts and simplifies deep flows like:

```
router.routeTo(.a, via: .sheet, target: .deepest)
router.routeTo(.b, via: .fullScreenCover, target: .deepest)

```
🧭 New Helpers
```
router.isRoot           // true if no parent
router.isFullyAtRoot    // true if root, empty path, no modals
router.hasChild         // true if there's a presented router
```
These help manage flow state in a cleaner way.